### PR TITLE
Улучшение поиска записей для asterisk 13

### DIFF
--- a/lib/PearlPBX/Report.pm
+++ b/lib/PearlPBX/Report.pm
@@ -219,11 +219,12 @@ sub pearlpbx_player {
 	my $cdr_start = shift; 
 	my $cdr_src = shift; 
 	my $cdr_dst = shift;
-	my $disposition = shift; 
+	my $disposition = shift;
+    my $uniqueid = shift;  
 
 	if ($disposition =~ /ANSWERED/i ) { 
 
-		return '<a data-toggle="modal" href="#pearlpbx_player" onClick="turnOnPBXPlayer(\''.$cdr_start.'\',\''.$cdr_src.'\',\''.$cdr_dst.'\')">link</a>';
+		return '<a data-toggle="modal" href="#pearlpbx_player" onClick="turnOnPBXPlayer(\''.$cdr_start.'\',\''.$cdr_src.'\',\''.$cdr_dst.'\',\''.$uniqueid.'\')">link</a>';
 
   } 
 	return ''; 

--- a/lib/PearlPBX/Report/Recordings.pm
+++ b/lib/PearlPBX/Report/Recordings.pm
@@ -79,11 +79,12 @@ sub report {
 		my $start = $params->{'start'}; 
 		my $src = $params->{'src'}; 
 		my $dst = $params->{'dst'}; 
+        my $uniqueid = $params->{'uniqueid'}; 
 
-    my $sql = "select id,uline_id,original_file,result_file, cdr_start, cdr_src, cdr_dst from integration.recordings where cdr_start = ? and ( cdr_src = ? or cdr_dst = ?) order by id"; 
+    my $sql = "select id,uline_id,original_file,result_file, cdr_start, cdr_src, cdr_dst from integration.recordings where cdr_uniqueid = ? and cdr_start between (?::timestamp - '5 seconds'::interval ) and ? and ( cdr_src = ? ) order by id"; 
 
     my $sth = $this->{dbh}->prepare($sql);
-    eval { $sth->execute( $start, $src, $dst ); };
+    eval { $sth->execute( $uniqueid, $start, $start, $src ); };
     if ($@) {
         $this->{error} = $this->{dbh}->errstr;
         return undef;

--- a/lib/PearlPBX/Report/Recordings.pm
+++ b/lib/PearlPBX/Report/Recordings.pm
@@ -81,10 +81,10 @@ sub report {
 		my $dst = $params->{'dst'}; 
         my $uniqueid = $params->{'uniqueid'}; 
 
-    my $sql = "select id,uline_id,original_file,result_file, cdr_start, cdr_src, cdr_dst from integration.recordings where cdr_uniqueid = ? and cdr_start between (?::timestamp - '5 seconds'::interval ) and ? and ( cdr_src = ? ) order by id"; 
+    my $sql = "select id,uline_id,original_file,result_file, cdr_start, cdr_src, cdr_dst from integration.recordings where cdr_uniqueid = ? and cdr_src = ? order by id"; 
 
     my $sth = $this->{dbh}->prepare($sql);
-    eval { $sth->execute( $uniqueid, $start, $start, $src ); };
+    eval { $sth->execute( $uniqueid, $src ); };
     if ($@) {
         $this->{error} = $this->{dbh}->errstr;
         return undef;

--- a/lib/PearlPBX/Report/cdrfilter.pm
+++ b/lib/PearlPBX/Report/cdrfilter.pm
@@ -91,7 +91,7 @@ sub report {
     my $dstchannel = $this->_sql_cond_dstchannel ($params->{'dstchannel'}); 
 
     my $sql = "select calldate,src,dst,split_part(channel,'-',1) as channel, 
-     split_part(dstchannel,'-',1) as dstchannel,disposition,billsec 
+     split_part(dstchannel,'-',1) as dstchannel,disposition,billsec,uniqueid 
       from public.cdr where calldate between ? and ? 
        and $sql_cond $src $dst $channel $dstchannel $disposition $billsec order by calldate";
 

--- a/share/reports/templates/cdrfilter.html
+++ b/share/reports/templates/cdrfilter.html
@@ -23,7 +23,7 @@
 <td>[% cdr_key.dstchannel %]</td>
 <td>[% cdr_key.disposition %]</td>
 <td>[% cdr_key.billsec %]</td>
-<td>[% pearlpbx_player(cdr_key.calldate,cdr_key.src,cdr_key.dst,cdr_key.disposition) %]</td>
+<td>[% pearlpbx_player(cdr_key.calldate,cdr_key.src,cdr_key.dst,cdr_key.disposition,cdr_key.uniqueid) %]</td>
 </tr>
 [% END %]
 </tbody>

--- a/sql/pearlpbx.sql
+++ b/sql/pearlpbx.sql
@@ -721,7 +721,8 @@ CREATE TABLE recordings (
     next_record bigint,
 		cdr_start timestamp with time zone,
 		cdr_src character varying,
-		cdr_dst character varying
+		cdr_dst character varying,
+		cdr_uniqueid character varying (150)
 );
 
 
@@ -1896,8 +1897,12 @@ create index next_uline_id on recordings(uline_id, next_record);
 create index rec_cdr_start on recordings(cdr_start);
 create index rec_cdr_src on recordings (cdr_src);
 
+create index rec_uniqueid on recordings (cdr_uniqueid); 
+
+set search_path to public; 
 create index queue_parsed_id_idx on queue_parsed ( id );
 create index queue_parsed_callerid_idx on queue_parsed ( callerid );
 create index queue_parsed_queue_idx on queue_parsed ( queue );
 create index quque_parsed_status_idx on queue_parsed (status);
+
 

--- a/web/js/pearlpbx.js
+++ b/web/js/pearlpbx.js
@@ -2105,18 +2105,20 @@ function pearlpbx_parse_period (dateFrom, dateTo, timeFrom, timeTo) {
 
 }
 
-function turnOnPBXPlayer (cdr_start, cdr_src, cdr_dst ) { 
+function turnOnPBXPlayer (cdr_start, cdr_src, cdr_dst, uniqueid ) { 
 
  //alert (cdr_start + ' ' + cdr_src + ' ' + cdr_dst ); 
  $('#param_cdr_start').text(cdr_start);
  $('#param_cdr_src').text(cdr_src);
  $('#param_cdr_dst').text(cdr_dst);  
+ $('#param_uniqueid').text(uniqueid); 
 
  $.get("recordings.pl",
     { "list-recordings": 1,
 			start: cdr_start,
 			src: cdr_src, 
-			dst: cdr_dst 
+			dst: cdr_dst,
+            uniqueid: uniqueid 
     },function(data)
     {
 

--- a/web/recordings.pl
+++ b/web/recordings.pl
@@ -32,6 +32,7 @@ my $listrecordings = $pearl->{cgi}->param('list-recordings');
 my $cdr_start = $pearl->{cgi}->param('start'); 
 my $cdr_src = $pearl->{cgi}->param('src'); 
 my $cdr_dst = $pearl->{cgi}->param('dst');
+my $uniqueid = $pearl->{cgi}->param('uniqueid'); 
 
 unless ( defined ( $listrecordings ) 
 	or defined ( $cdr_start ) 


### PR DESCRIPTION
Обнаружилось, что в 13-м астериске cdr_start равен моменту, когда разговор таки начинается. 
А не в момент открытия канала.  
Поэтому пришлось добавить uniqueid в параметры записи и поиска разговоров. 
Сделано: 
1) Добавлена колонка uniqueid в integration.recordings 
2) Имя файла Y/M/D/HHMMSS_src_uniqueid 
3) Модуль cdrfilter.pm выдает в результирующий html в том числе uniqueid
4) pearlpbx.js формирует открытие плеера с дополнительным параметром uniqueid 
5) Player спрашивает у recordings?uniqueid=${UNIQUEID}  в том числе 
6) recorginds.pm тоже ищет по uniqueid в том числе.  
